### PR TITLE
Booking Management API v1.6

### DIFF
--- a/Booking-Management/Booking Management API v2021.04.postman_collection.json
+++ b/Booking-Management/Booking Management API v2021.04.postman_collection.json
@@ -1,0 +1,5009 @@
+{
+	"info": {
+		"_postman_id": "c1602127-bbe9-4556-99d2-6e0b1ee93134",
+		"name": "Booking Management API v2021.04",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Authentication",
+			"item": [
+				{
+					"name": "REST Authorize",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Basic {{secret}}",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "grant_type=client_credentials"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v2/auth/token",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v2",
+								"auth",
+								"token"
+							]
+						},
+						"description": "\n\n[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/resources/getting_started_with_sabre_apis/how_to_get_a_token#3sub3)\n\n[//]: # \"End\""
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Get Booking",
+			"item": [
+				{
+					"name": "GetBooking /v1 General",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"confirmationId\": \"LLLNJR\"\r\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"getBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "GetBooking /v1 General + surname",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"confirmationId\": \"RPMHRI\",\r\n  \"surname\": \"Power\"\r\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"getBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "GetBooking /v1 Return Only Flights",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"confirmationId\": \"MCBBWT\",\r\n  \"returnOnly\":\r\n  [ \"FLIGHTS\"]\r\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"getBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "GetBooking /v1 GraphQL",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "graphql",
+							"graphql": {
+								"query": "{\r\n    getBooking(confirmationId: \"GFKVCA\") {\r\n        travelers\r\n        {\r\n            givenName\r\n            surname\r\n            passengerCode\r\n            \r\n        }\r\n        flights\r\n        {\r\n            flightNumber\r\n            fromAirportCode\r\n            toAirportCode\r\n            departureDate\r\n            arrivalDate\r\n        }\r\n        \r\n    }\r\n}",
+								"variables": ""
+							}
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking/graphql",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"getBooking",
+								"graphql"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Cancel Booking",
+			"item": [
+				{
+					"name": "Cancel Booking /v1 Cancel All",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"confirmationId\": \"YGHENP\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true,\n    \"errorHandlingPolicy\": \"ALLOW_PARTIAL_CANCEL\"\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Booking /v1 Cancel All + Change PCC",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"targetPcc\": \"IPCC\",\n    \"confirmationId\": \"FDAJBQ\",\n    \"cancelAll\": true\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Booking /v1 Cancel by Item Id - Flights",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"confirmationId\": \"RFGSGN\",\n  \"bookingSource\": \"SABRE\",\n  \"retrieveBooking\": false,\n  \"cancelAll\": false,\n  \"errorHandlingPolicy\": \"HALT_ON_ERROR\",\n  \"flights\": [\n    {\n      \"itemId\": 9\n    }\n  ]\n \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Booking /v1 Cancel by Item Id - Hotels",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"confirmationId\": \"LEZOPS\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": false,\n    \"errorHandlingPolicy\": \"HALT_ON_ERROR\",\n    \"hotels\": [\n        {\n            \"itemId\": 42\n        },\n                {\n            \"itemId\": 43\n        },\n                {\n            \"itemId\": 44\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Booking /v1 Cancel by Item Id - Flights, Hotels, Cars",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"confirmationId\": \"DLPLZC\",\r\n    \"cars\": [\r\n        {\r\n            \"itemId\": 77\r\n        }\r\n    ],\r\n    \"flights\": [\r\n        {\r\n            \"itemId\": 2\r\n        },\r\n        {\r\n            \"itemId\": 3\r\n        },\r\n        {\r\n            \"itemId\": 4\r\n        },\r\n        {\r\n            \"itemId\": 88\r\n        }\r\n    ],\r\n    \"hotels\": [\r\n        {\r\n            \"itemId\": 25\r\n        },\r\n        {\r\n            \"itemId\": 220\r\n        }\r\n    ]\r\n}\r\n\r\n"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Booking /v1 Cancel by Segment Sequence",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"confirmationId\": \"UMODWZ\",\r\n    \"segments\": [\r\n        {\r\n            \"sequence\": 1\r\n        },\r\n        {\r\n            \"sequence\": 3\r\n        }\r\n    ]\r\n}\r\n"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Booking /v1 Cancel by Segment Id",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Conversation-ID",
+								"value": "{{conv_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"confirmationId\": \"UMODWZ\",\r\n    \"segments\": [\r\n        {\r\n            \"id\": 38\r\n        },\r\n        {\r\n            \"id\": 26\r\n        }\r\n    ]\r\n}\r\n"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Booking /v1 Cancel All and Void corresponding tickets",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true,\n    \"flightTicketOperation\": \"VOID\",\n    \"errorHandlingPolicy\": \"HALT_ON_ERROR\"\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Booking /v1 Cancel Flights and Void corresponding tickets",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": false,\n    \"cancelAll\": false,\n    \"flightTicketOperation\": \"VOID\",\n    \"errorHandlingPolicy\": \"HALT_ON_ERROR\",\n    \"flights\": [\n        {\n            \"itemId\": 25\n        },\n        {\n            \"itemId\": 26\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Booking /v1 Cancel NDC order by means of a void or refund offer",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"retrieveBooking\": true,\n    \"offerItemId\": \"cb7778589bcbklg7tkkp8sdo50\"\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"cancelBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Cancel Flight Tickets (Check/Void/Refund)",
+			"item": [
+				{
+					"name": "Check Flight Tickets",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"tickets\": [\n      {\n        \"number\": \"6077531617197\"\n      },\n      {\n        \"number\": \"6077531617198\"\n      }\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/checkFlightTickets",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"checkFlightTickets"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Check Flight Tickets with refundQualifiers",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"tickets\": [\n      {\n        \"number\": \"6077531617197\",\n        \"refundQualifiers\": {\n            \"commissionPercent\": \"5.00\"\n        }\n      },\n      {\n        \"number\": \"6077531617198\",\n        \"refundQualifiers\": {\n            \"overrideCancelFee\": \"100.00\"\n        }\n      }\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/checkFlightTickets",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"checkFlightTickets"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Check Flight Tickets for a confirmationId",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"confirmationId\": \"1SXXXCITUW8P4\"\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/checkFlightTickets",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"checkFlightTickets"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Void Flight Tickets - with ALLOW_PARTIAL_CANCEL policy",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"tickets\": [\n    \"6071237616558\",\n    \"6074567616559\",\n    \"6077897616560\"\n  ],\n  \"errorHandlingPolicy\": \"ALLOW_PARTIAL_CANCEL\"  \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/voidFlightTickets",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"voidFlightTickets"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Void Flight Tickets - with HALT_ON_ERROR policy",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\n  \"tickets\": [\n    \"6077531617197\",\n    \"6077531617198\",\n    \"6077531617199\"\n  ],\n  \"errorHandlingPolicy\": \"HALT_ON_ERROR\"  \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/voidFlightTickets",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"voidFlightTickets"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Void Flight Tickets - Change PCC",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"targetPcc\": \"G7QE\",\n  \"tickets\": [\n    \"6077531617197\",\n    \"6077531617198\",\n    \"6077531617199\"\n  ],\n  \"errorHandlingPolicy\": \"HALT_ON_ERROR\"  \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/voidFlightTickets",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"voidFlightTickets"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Refund Flight Tickets",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"tickets\": [\n      {\n        \"number\": \"6077531617197\"\n      },\n      {\n        \"number\": \"6077531617198\"\n      }\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/refundFlightTickets",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"refundFlightTickets"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "Refund Flight Tickets with refundQualifiers",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"tickets\": [\n      {\n        \"number\": \"6077531617197\",\n        \"refundQualifiers\": {\n            \"commissionPercent\": \"5.00\"\n        }\n      },\n      {\n        \"number\": \"6077531617198\",\n        \"refundQualifiers\": {\n            \"overrideCancelFee\": \"100.00\"\n        }\n      }\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/refundFlightTickets",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"refundFlightTickets"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Create Booking",
+			"item": [
+				{
+					"name": "createBooking - Air NDC  with ProfileName",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"profiles\": [\n\t\t{\n\t\t\t\"profileName\": \"{{profileName}}\",\n\t\t\t\"profileTypeCode\": \"TVL\",\n\t\t\t\"domainId\": \"{{pcc}}\"\n\t\t}\n\t],\n\t\"flightOffer\": {\n\t\t\"offerId\": \"{{price_offer_id}}\",\n\t\t\"selectedOfferItems\": [\n\t\t\t\"{{price_offer_item_id}}\"\n\t\t]\n\t},\n\t\t\"travelers\": [\n\t\t{\n\t\t\t\"id\": \"{{price_passenger_id}}\"\n\t\t}\n\t]\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air NDC  with ProfileId",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\n\t\"profiles\": [ \n\t\t{\n\t\t\"uniqueId\": \"{{profileId}}\",\n\t\t\"profileTypeCode\": \"TVL\",\n\t\t\"domainId\": \"{{pcc}}\"\n\t\t}\n\t],\n\t\t\"flightOffer\": {\n\t\t\"offerId\": \"{{price_offer_id}}\",\n\t\t\"selectedOfferItems\": [\n\t\t\t\"{{price_offer_item_id}}\"\n\t\t]\n\t},\n\t\t\"travelers\": [\n\t\t{\n\t\t\t\"id\": \"{{price_passenger_id}}\"\n\t\t}\n\t]\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air NDC Payload",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\n\t\"flightOffer\": {\n\t\t\"offerId\": \"{{price_offer_id}}\",\n\t\t\"selectedOfferItems\": [\n\t\t\t\"{{price_offer_item_id}}\"\n\t\t]\n\t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"id\": \"{{price_passenger_id}}\",\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n\t\t\t\"customerNumber\": \"1234567\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\"\n      ],\n      \"phones\": [\n        \"123456\"\n      ]\n    }\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with ProfileId",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n\t\t},\n\t\"profiles\": [ \n\t\t{\n\t\t\"uniqueId\": \"{{profileId}}\",\n\t\t\"profileTypeCode\": \"TVL\",\n\t\t\"domainId\": \"{{pcc}}\"\n\t\t}\n\t],\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t]\n\t}\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with Profile filter",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n\t\t},\n\t\"profiles\": [ \n\t\t{\n\t\t\"uniqueId\": \"{{profileId}}\",\n\t\t\"profileTypeCode\": \"TVL\",\n\t\t\"domainId\": \"{{pcc}}\"\n\t\t}\n\t],\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t]\n\t}\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with pricing",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n                {\n\t\t\t\"givenName\": \"Infant\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2020-01-23\",\n\t\t\t\"passengerCode\": \"INF\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with seats",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n                {\n\t\t\t\"givenName\": \"Infant\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2020-01-23\",\n\t\t\t\"passengerCode\": \"INF\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\",\n                \"seats\": [\n                    {\n                        \"travelerIndex\": \"1\",\n                        \"number\": \"20C\"\n                    },\n                    {\n                        \"travelerIndex\": \"3\",\n                        \"number\": \"20D\"\n                    }\n                ]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\",\n                                \"seats\": [\n                    {\n                        \"travelerIndex\": \"1\",\n                        \"number\": \"19C\"\n                    },\n                    {\n                        \"travelerIndex\": \"3\",\n                        \"number\": \"19D\"\n                    }\n                ]\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with pricing and FOP",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n                {\n\t\t\t\"givenName\": \"Infant\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2020-01-23\",\n\t\t\t\"passengerCode\": \"INF\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n            \"qualifiers\": {\n                \"payment\": {\n                    \"primaryFormOfPayment\": 1\n                }\n            }\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        },\n        \"formsOfPayment\": [\n            {\n                \"type\": \"PAYMENTCARD\",\n                \"cardTypeCode\": \"VI\",\n                \"cardNumber\": \"4005111111111136\",\n                \"expiryDate\": \"2024-07\"\n            }\n        ]\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air no pricing",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n                {\n\t\t\t\"givenName\": \"Infant\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2020-01-23\",\n\t\t\t\"passengerCode\": \"INF\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with custom haltOnStatus",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n                {\n\t\t\t\"givenName\": \"Infant\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2020-01-23\",\n\t\t\t\"passengerCode\": \"INF\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n        \"haltOnFlightStatusCodes\": [\"NN\"],\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with multi pricing (per flight)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Smith\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Smith\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"CNN\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        \"qualifiers\": {\n            \"validatingAirlineCode\": \"EY\",\n            \"flightIndices\": [1]\n        }\n        },\n                {\n        \"qualifiers\": {\n            \"validatingAirlineCode\": \"EY\",\n            \"flightIndices\": [2]\n        }\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with price comparison",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Smith\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Smith\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"CNN\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n            \"priceComparisons\": [\n                {\n                    \"desiredAmount\": \"5300.00\",\n                    \"comparisonType\": \"INCREASE_BY_AMOUNT\",\n                    \"amount\": \"30.00\"\n                },\n                                {\n                    \"desiredAmount\": \"5300.00\",\n                    \"comparisonType\": \"DECREASE_BY_AMOUNT\",\n                    \"amount\": \"30.00\"\n                }\n            ]\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with identity documents",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Smith\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n            \"identityDocuments\": [\n            {\n                \"documentNumber\": \"0123456789\",\n                \"documentType\": \"PASSPORT\",\n                \"expiryDate\": \"2024-07-09\",\n                \"issuingCountryCode\": \"US\",\n                \"residenceCountryCode\": \"US\",\n                \"givenName\": \"John\",\n                \"middleName\": \"Jack\",\n                \"surname\": \"Smith\",\n                \"birthDate\": \"1980-12-02\",\n                \"gender\": \"MALE\"\n            }\n            ]\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        \"qualifiers\": {\n            \"validatingAirlineCode\": \"EY\"\n        }\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with remarks and other services",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"agency\": {\n        \"address\": {\n            \"name\": \"John Smith\",\n            \"street\": \"1230 Ellen Ave, apt 10\",\n            \"city\": \"Dallas\",\n            \"stateProvince\": \"TX\",\n            \"postalCode\": \"75063\",\n            \"countryCode\": \"US\",\n            \"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n        },\n        \"agencyCustomerNumber\": \"1234567\",\n        \"ticketingPolicy\": \"TODAY\"\n    },\n    \"travelers\": [\n        {\n            \"givenName\": \"John\",\n            \"surname\": \"Smith\",\n            \"birthDate\": \"1970-01-23\",\n            \"passengerCode\": \"ADT\",\n            \"identityDocuments\": [\n                {\n                    \"documentNumber\": \"0123456789\",\n                    \"documentType\": \"PASSPORT\",\n                    \"expiryDate\": \"2024-07-09\",\n                    \"issuingCountryCode\": \"US\",\n                    \"residenceCountryCode\": \"US\",\n                    \"givenName\": \"John\",\n                    \"middleName\": \"Jack\",\n                    \"surname\": \"Smith\",\n                    \"birthDate\": \"1980-12-02\",\n                    \"gender\": \"MALE\"\n                }\n            ]\n        }\n    ],\n    \"contactInfo\": {\n        \"emails\": [\n            \"travel@sabre.com\",\n            \"travel2@sabre.com\"\n        ],\n        \"phones\": [\n            \"+123456\"\n        ]\n    },\n    \"flightDetails\": {\n        \"flights\": [\n            {\n                \"flightNumber\": 463,\n                \"airlineCode\": \"EY\",\n                \"fromAirportCode\": \"MEL\",\n                \"toAirportCode\": \"AUH\",\n                \"departureDate\": \"{{start_date}}\",\n                \"departureTime\": \"16:15\",\n                \"bookingClass\": \"Y\",\n                \"marriageGroup\": false,\n                \"flightStatusCode\": \"NN\"\n            },\n            {\n                \"flightNumber\": 460,\n                \"airlineCode\": \"EY\",\n                \"fromAirportCode\": \"AUH\",\n                \"toAirportCode\": \"MEL\",\n                \"departureDate\": \"{{end_date}}\",\n                \"departureTime\": \"21:45\",\n                \"bookingClass\": \"Y\",\n                \"marriageGroup\": false,\n                \"flightStatusCode\": \"NN\"\n            }\n        ],\n        \"flightPricing\": [\n            {\n                \"qualifiers\": {\n                    \"validatingAirlineCode\": \"EY\"\n                }\n            }\n        ]\n    },\n    \"remarks\": [\n        {\n            \"type\": \"GENERAL\",\n            \"text\": \"TEST REMARK\"\n        }\n    ],\n    \"otherServices\": [\n        {\n            \"airlineCode\": \"EY\",\n            \"travelerIndex\": 1,\n            \"serviceMessage\": \"TEST OTHER SERVICE\"\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with loyaltyPrograms",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n            \"loyaltyPrograms\": [\n                {\n                \"supplierCode\": \"LO\",\n                \"programNumber\": \"992001557133700\",\n                \"tierLevel\": \"1\",\n                \"receiverCode\": \"LO\"\n              }\n            ]\n\t\t},\n                {\n\t\t\t\"givenName\": \"Infant\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2020-01-23\",\n\t\t\t\"passengerCode\": \"INF\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n                        \"loyaltyPrograms\": [\n              {\n                \"supplierCode\": \"AA\",\n                \"programNumber\": \"ZZZZZZ\",\n                \"tierLevel\": \"1\",\n                \"receiverCode\": \"AA\"\n              }\n            ]\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with loyaltyPrograms + pricing qualifiers + Credit card",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"agency\": {\n        \"address\": {\n            \"name\": \"John Smith\",\n            \"street\": \"1230 Ellen Ave, apt 10\",\n            \"city\": \"Dallas\",\n            \"stateProvince\": \"TX\",\n            \"postalCode\": \"75063\",\n            \"countryCode\": \"US\",\n            \"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n        }\n    },\n    \"travelers\": [\n        {\n            \"givenName\": \"John\",\n            \"surname\": \"Kowalski\",\n            \"birthDate\": \"1970-01-23\",\n            \"passengerCode\": \"ADT\"\n        },\n        {\n            \"givenName\": \"Infant\",\n            \"surname\": \"Mrozicki\",\n            \"birthDate\": \"2020-01-23\",\n            \"passengerCode\": \"INF\"\n        },\n        {\n            \"givenName\": \"All\",\n            \"surname\": \"Mrozicki\",\n            \"birthDate\": \"2000-01-23\",\n            \"passengerCode\": \"ADT\"\n         }\n    ],\n    \"contactInfo\": {\n        \"emails\": [\n            \"travel@sabre.com\"\n        ],\n        \"phones\": [\n            \"+48666555444\"\n        ]\n    },\n    \"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 461,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"22:25\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 460,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"21:45\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n            {\n                \"qualifiers\": {\n                    \"commissionPercentage\": \"10.00\",\n                    \"payment\": {\n                        \"primaryFormOfPayment\": 1\n                    }\n                }\n            }\n        ]\n    },\n    \"payment\": {\n        \"formsOfPayment\": [\n            {\n                \"type\": \"PAYMENTCARD\",\n                \"cardTypeCode\": \"VI\",\n                \"cardNumber\": \"4537156488578956\",\n                \"expiryDate\": \"2024-07\"\n            }\n        ]\n    }\n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air with Changed PCC",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"targetPcc\": \"G7HE\",\n     \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Smith\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Smith\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        \"qualifiers\": {\n            \"validatingAirline\": \"EY\"\n        }\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Passive Air segment",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n                {\n\t\t\t\"givenName\": \"Infant\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2020-01-23\",\n\t\t\t\"passengerCode\": \"INF\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"YK\",\n                \"confirmationId\": \"ABC123\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"{{end_date}}\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"YK\",\n                \"confirmationId\": \"ABC123\"\n\t\t\t}\n\t\t]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				},
+				{
+					"name": "createBooking - Air LCC",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Conversation-ID",
+								"type": "text",
+								"value": "{{conv_id}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n                {\n\t\t\t\"givenName\": \"Infant\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2020-01-23\",\n\t\t\t\"passengerCode\": \"INF\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 2437,\n\t\t\t\t\"airlineCode\": \"FR\",\n\t\t\t\t\"fromAirportCode\": \"KRK\",\n\t\t\t\t\"toAirportCode\": \"STN\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"21:45\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\",\n                \"source\": \"LCC\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+						},
+						"url": {
+							"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+							"host": [
+								"{{rest_endpoint}}"
+							],
+							"path": [
+								"v1",
+								"trip",
+								"orders",
+								"createBooking"
+							]
+						},
+						"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Workflows",
+			"item": [
+				{
+					"name": "1 - Air NDC Shop, Price Check, Book, Cancel",
+					"item": [
+						{
+							"name": "0. REST Authorize ATK",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Basic {{secret}}",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "grant_type=client_credentials"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/auth/token",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"auth",
+										"token"
+									]
+								},
+								"description": "\n\n[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/resources/getting_started_with_sabre_apis/how_to_get_a_token#3sub3)\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "1. Bargain Finder Max /v2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"OTA_AirLowFareSearchRQ\": {\n\t\t\"Version\": \"1\",\n\t\t\"POS\": {\n\t\t\t\"Source\": [{\n\t\t\t\t\t\"PseudoCityCode\": \"{{pcc}}\",\n\t\t\t\t\t\"RequestorID\": {\n\t\t\t\t\t\t\"Type\": \"1\",\n\t\t\t\t\t\t\"ID\": \"1\",\n\t\t\t\t\t\t\"CompanyName\": {\n\t\t\t\t\t\t\t\"Code\": \"TN\"\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t]\n\t\t},\n\t\t\"OriginDestinationInformation\": [{\n\t\t\t\t\"RPH\": \"1\",\n\t\t\t\t\"DepartureDateTime\": \"{{start_date}}T00:00:00\",\n\t\t\t\t\"OriginLocation\": {\n\t\t\t\t\t\"LocationCode\": \"DEN\"\n\t\t\t\t},\n\t\t\t\t\"DestinationLocation\": {\n\t\t\t\t\t\"LocationCode\": \"ABQ\"\n\t\t\t\t}\n\t\t\t}, {\n\t\t\t\t\"RPH\": \"2\",\n\t\t\t\t\"DepartureDateTime\": \"{{end_date}}T00:00:00\",\n\t\t\t\t\"OriginLocation\": {\n\t\t\t\t\t\"LocationCode\": \"ABQ\"\n\t\t\t\t},\n\t\t\t\t\"DestinationLocation\": {\n\t\t\t\t\t\"LocationCode\": \"DEN\"\n\t\t\t\t}\n\t\t\t}\n\t\t],\n\t\t\"TravelPreferences\": {\n\t\t\t\"TPA_Extensions\": {\n\t\t\t\t\"NumTrips\": {\n\t\t\t\t\t\"Number\": 10\n\t\t\t\t},\n\t\t\t\t\"DataSources\": {\n\t\t\t\t\t\"NDC\": \"Enable\",\n\t\t\t\t\t\"ATPCO\": \"Disable\",\n\t\t\t\t\t\"LCC\": \"Disable\"\n\t\t\t\t},\n                 \"PreferNDCSourceOnTie\": {\n                    \"Value\": true\n                }\n\n\t\t\t}\n\t\t},\n\t\t\"TravelerInfoSummary\": {\n\t\t\t\"AirTravelerAvail\": [{\n\t\t\t\t\t\"PassengerTypeQuantity\": [{\n\t\t\t\t\t\t\t\"Code\": \"ADT\",\n\t\t\t\t\t\t\t\"Quantity\": 1\n\t\t\t\t\t\t}\n\t\t\t\t\t]\n\t\t\t\t}\n\t\t\t]\n\t\t},\n\t\t\"TPA_Extensions\": {\n\t\t\t\"IntelliSellTransaction\": {\n\t\t\t\t\"RequestType\": {\n\t\t\t\t\t\"Name\": \"200ITINS\"\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/offers/shop",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"offers",
+										"shop"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max), [Resources](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/resources)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "2. Offers Price /v1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"query\": [\n        {\n            \"offerItemId\": [\n                \"{{shop_offer_item_id}}\"\n            ]\n        }\n    ],\n    \"params\": {\n        \"formOfPayment\": [\n            {\n                \"binNumber\": \"545251\",\n                \"subCode\": \"FDA\",\n                \"cardType\" : \"MC\"\n            }\n        ]\n    }\n}\n"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/offers/price",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"offers",
+										"price"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/book/offer_price), [Resources](https://developer.sabre.com/docs/rest_apis/air/book/offer_price/resources)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "3. createBooking",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\n\t\"flightOffer\": {\n\t\t\"offerId\": \"{{price_offer_id}}\",\n\t\t\"selectedOfferItems\": [\n\t\t\t\"{{price_offer_item_id}}\"\n\t\t]\n\t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"id\": \"{{price_passenger_id}}\",\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n\t\t\t\"customerNumber\": \"1234567\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\"\n      ],\n      \"phones\": [\n        \"123456\"\n      ]\n    }\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"createBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "GetBooking /v1 General",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"confirmationId\": \"TADPGN\"\r\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"getBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "4. Cancel Booking /v1 Cancel All",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"cancelBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "2 - Profiles, Air NDC Shop, Price Check, Book, Cancel",
+					"item": [
+						{
+							"name": "0 - Create Profile",
+							"item": [
+								{
+									"name": "SessionCreateRQ (Stateful ATH) create session and prepare vars Copy",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"// Generate a unique ID for profile services\r",
+													"var uuid = require('uuid');\r",
+													"var myUUID = uuid();\r",
+													"console.log(myUUID);\r",
+													"\r",
+													"//cleanup\r",
+													"pm.environment.unset('filterName')\r",
+													"pm.environment.unset('profileName')\r",
+													"\r",
+													"pm.environment.set('filterName','CreateBookingFilter '+myUUID);\r",
+													"pm.environment.set('profileName','CreateBookingProfile '+myUUID);\r",
+													"\r",
+													"console.log(pm.environment.get('filterName'))\r",
+													"console.log(pm.environment.get('profileName'))\r",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "text/xml"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">\n    <SOAP-ENV:Header>\n        <MessageHeader xmlns=\"http://www.ebxml.org/namespaces/messageHeader\">\n            <From>\n                <PartyId>Agency</PartyId>\n            </From>\n            <To>\n                <PartyId>Sabre_API</PartyId>\n            </To>\n            <ConversationId>2019.09.DevStudio</ConversationId>\n            <Action>SessionCreateRQ</Action>\n        </MessageHeader>\n        <Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\">\n            <UsernameToken>\n                <Username>{{username}}</Username>\n                <Password>{{password}}</Password>\n                <Organization>{{pcc}}</Organization>\n                <Domain>DEFAULT</Domain>\n            </UsernameToken>\n        </Security>\n    </SOAP-ENV:Header>\n    <SOAP-ENV:Body>\n    \t\n<SessionCreateRQ returnContextID=\"true\">\n\t<POS>\n\t\t<Source PseudoCityCode=\"{{pcc}}\"/>\n\t</POS>\n</SessionCreateRQ>\n\n    </SOAP-ENV:Body>\n</SOAP-ENV:Envelope>"
+										},
+										"url": {
+											"raw": "{{soap_endpoint}}",
+											"host": [
+												"{{soap_endpoint}}"
+											]
+										},
+										"description": "Used to create stateful sessions on Sabre's Passenger Sales System\r\nAlso used to set variables for Stateful API's"
+									},
+									"response": []
+								},
+								{
+									"name": "EPS_EXT_ProfileCreateRQ (Stateful ATH) create filter",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"const xml2js = require('xml2js');\r",
+													"\r",
+													"// Parse response and remove namespaces (prefixes)\r",
+													"// Solves problem when specific APIs return different namespaces randombly ie. ns8, ns9: TP APIs\r",
+													"const parseString = xml2js.parseString;\r",
+													"const parseOptions = { tagNameProcessors: [xml2js.processors.stripPrefix] };\r",
+													"\r",
+													"parseString(responseBody, parseOptions, (err, result) => {\r",
+													"    const filterId = result.Envelope.Body[0].Sabre_OTA_ProfileCreateRS[0].Filter[0].$.FilterID;\r",
+													"    pm.environment.set('filterId', filterId);\r",
+													"});\r",
+													"\r",
+													"console.log(\"Filter id : \"+pm.environment.get('filterId'))"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"//cleanup\r",
+													"pm.environment.unset('filterId')"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "text/xml",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{header}}\r\n\r\n<Sabre_OTA_ProfileCreateRQ xmlns=\"http://www.sabre.com/eps/schemas\" Version=\"6.55\">\r\n\t<Filter CreateDateTime=\"{{start_date}}T00:00:00\" UpdateDateTime=\"{{start_date}}T00:00:00\" FilterID=\"*\" DomainID=\"{{pcc}}\" ClientCode=\"TN\" ClientContextCode=\"SBS\" FilterName=\"{{filterName}}\" FilterTypeCode=\"TVL\">\r\n\t\t<Profile>\r\n\t\t\t<TPA_Identity ClientCode=\"TN\" ClientContextCode=\"SBS\" UniqueID=\"*\" ProfileTypeCode=\"TVL\" DomainID=\"{{pcc}}\"/>\r\n\t\t\t<Traveler>\r\n\t\t\t\t<Customer>\r\n\t\t\t\t\t<PersonName InformationText=\"Info\">\r\n\t\t\t\t\t\t<GivenName>John</GivenName>\r\n\t\t\t\t\t\t<SurName>Kowalski</SurName>\r\n\t\t\t\t\t</PersonName>\r\n\t\t\t\t\t<Telephone>\r\n\t\t\t\t\t\t<FullPhoneNumber>6826051000</FullPhoneNumber>\r\n\t\t\t\t\t</Telephone>\r\n\t\t\t\t\t<Email EmailAddress=\"Test.Create.Booking@Sabre.com\"/>\r\n\t\t\t\t</Customer>\r\n\t\t\t</Traveler>\r\n\t\t</Profile>\r\n\t</Filter>\r\n</Sabre_OTA_ProfileCreateRQ>\r\n\r\n{{footer}}"
+										},
+										"url": {
+											"raw": "{{soap_endpoint}}",
+											"host": [
+												"{{soap_endpoint}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "EPS_EXT_ProfileCreateRQ (Stateful ATH) create profile",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"const xml2js = require('xml2js');\r",
+													"\r",
+													"\r",
+													"// Parse response and remove namespaces (prefixes)\r",
+													"// Solves problem when specific APIs return different namespaces randombly ie. ns8, ns9: TP APIs\r",
+													"const parseString = xml2js.parseString;\r",
+													"const parseOptions = { tagNameProcessors: [xml2js.processors.stripPrefix] };\r",
+													"\r",
+													"parseString(responseBody, parseOptions, (err, result) => {\r",
+													"    const filterId = result.Envelope.Body[0].Sabre_OTA_ProfileCreateRS[0].Profile[0].$.UniqueID;\r",
+													"    const profileName = result.Envelope.Body[0].Sabre_OTA_ProfileCreateRS[0].Profile[0].$.ProfileName;\r",
+													"    pm.environment.set('profileId', filterId);\r",
+													"    pm.environment.set('profileName', profileName);\r",
+													"});\r",
+													"\r",
+													"console.log(\"Profile id : \"+pm.environment.get('profileId'))\r",
+													"console.log(\"profileName : \"+pm.environment.get('profileName'))"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"//cleanup\r",
+													"pm.environment.unset('profileId')"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "text/xml",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{header}}\r\n\r\n<Sabre_OTA_ProfileCreateRQ xmlns=\"http://www.sabre.com/eps/schemas\" Version=\"6.55\">\r\n\t<Profile CreateDateTime=\"{{start_date}}T00:00:00\" UpdateDateTime=\"{{start_date}}T00:00:00\">\r\n\t\t<TPA_Identity ClientCode=\"TN\" ClientContextCode=\"SBS\" UniqueID=\"*\" ProfileTypeCode=\"TVL\" DomainID=\"{{pcc}}\" ProfileName=\"{{profileName}}\"/>\r\n\t\t<Traveler>\r\n\t\t\t<Customer BirthDate=\"1990-01-01\" GenderCode=\"M\">\r\n\t\t\t\t<PersonName>\r\n\t\t\t\t\t<GivenName>John</GivenName>\r\n\t\t\t\t\t\t<SurName>Smith</SurName>\r\n\t\t\t\t</PersonName>\r\n\t\t\t\t<Telephone>\r\n\t\t\t\t\t<FullPhoneNumber>6826051000</FullPhoneNumber>\r\n\t\t\t\t</Telephone>\r\n\t\t\t\t<Email EmailAddress=\"Test.Create.Booking@Sabre.com\"/>\r\n\t\t\t</Customer>\r\n\t\t\t<TPA_Extensions>\r\n\t\t\t\t<AssociatedFilters FilterID=\"{{filterId}}\" FilterName=\"{{filterName}}\" DomainID=\"{{pcc}}\" ClientCode=\"TN\" ClientContextCode=\"SBS\" CreateDateTime=\"{{start_date}}T00:00:00\" UpdateDateTime=\"{{start_date}}T00:00:00\"/>\r\n\t\t\t</TPA_Extensions>\r\n\t\t</Traveler>\r\n\t</Profile>\r\n</Sabre_OTA_ProfileCreateRQ>\r\n\r\n{{footer}}"
+										},
+										"url": {
+											"raw": "{{soap_endpoint}}",
+											"host": [
+												"{{soap_endpoint}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "SessionCloseRQ  (Stateful ATH) close session",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"//cleanup\r",
+													"pm.environment.unset('token')\r",
+													"pm.environment.unset('filterName')\r",
+													"pm.environment.unset('profileName')"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "text/xml"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{header}}\n\n<SessionCloseRQ>\n\t<POS>\n\t\t<Source PseudoCityCode=\"{{pcc}}\"/>\n\t</POS>\n</SessionCloseRQ>\n        \n{{footer}}"
+										},
+										"url": {
+											"raw": "{{soap_endpoint}}",
+											"host": [
+												"{{soap_endpoint}}"
+											]
+										},
+										"description": "Used to close stateful sessions on Sabre's Passenger Sales System"
+									},
+									"response": []
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "1 - Shop, Price Check, Book, Cancel (NDC)",
+							"item": [
+								{
+									"name": "0. REST Authorize ATK",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "noauth"
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/x-www-form-urlencoded",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Basic {{secret}}",
+												"type": "text"
+											},
+											{
+												"key": "Conversation-ID",
+												"value": "{{conv_id}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "grant_type=client_credentials"
+										},
+										"url": {
+											"raw": "{{rest_endpoint}}/v2/auth/token",
+											"host": [
+												"{{rest_endpoint}}"
+											],
+											"path": [
+												"v2",
+												"auth",
+												"token"
+											]
+										},
+										"description": "\n\n[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/resources/getting_started_with_sabre_apis/how_to_get_a_token#3sub3)\n\n[//]: # \"End\""
+									},
+									"response": []
+								},
+								{
+									"name": "1. Bargain Finder Max /v2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											},
+											{
+												"key": "Conversation-ID",
+												"value": "{{conv_id}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"OTA_AirLowFareSearchRQ\": {\n\t\t\"Version\": \"1\",\n\t\t\"POS\": {\n\t\t\t\"Source\": [{\n\t\t\t\t\t\"PseudoCityCode\": \"{{pcc}}\",\n\t\t\t\t\t\"RequestorID\": {\n\t\t\t\t\t\t\"Type\": \"1\",\n\t\t\t\t\t\t\"ID\": \"1\",\n\t\t\t\t\t\t\"CompanyName\": {\n\t\t\t\t\t\t\t\"Code\": \"TN\"\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t]\n\t\t},\n\t\t\"OriginDestinationInformation\": [{\n\t\t\t\t\"RPH\": \"1\",\n\t\t\t\t\"DepartureDateTime\": \"{{start_date}}T00:00:00\",\n\t\t\t\t\"OriginLocation\": {\n\t\t\t\t\t\"LocationCode\": \"DEN\"\n\t\t\t\t},\n\t\t\t\t\"DestinationLocation\": {\n\t\t\t\t\t\"LocationCode\": \"ABQ\"\n\t\t\t\t}\n\t\t\t}, {\n\t\t\t\t\"RPH\": \"2\",\n\t\t\t\t\"DepartureDateTime\": \"{{end_date}}T00:00:00\",\n\t\t\t\t\"OriginLocation\": {\n\t\t\t\t\t\"LocationCode\": \"ABQ\"\n\t\t\t\t},\n\t\t\t\t\"DestinationLocation\": {\n\t\t\t\t\t\"LocationCode\": \"DEN\"\n\t\t\t\t}\n\t\t\t}\n\t\t],\n\t\t\"TravelPreferences\": {\n\t\t\t\"TPA_Extensions\": {\n\t\t\t\t\"NumTrips\": {\n\t\t\t\t\t\"Number\": 10\n\t\t\t\t},\n\t\t\t\t\"DataSources\": {\n\t\t\t\t\t\"NDC\": \"Enable\",\n\t\t\t\t\t\"ATPCO\": \"Disable\",\n\t\t\t\t\t\"LCC\": \"Disable\"\n\t\t\t\t},\n                 \"PreferNDCSourceOnTie\": {\n                    \"Value\": true\n                }\n\n\t\t\t}\n\t\t},\n\t\t\"TravelerInfoSummary\": {\n\t\t\t\"AirTravelerAvail\": [{\n\t\t\t\t\t\"PassengerTypeQuantity\": [{\n\t\t\t\t\t\t\t\"Code\": \"ADT\",\n\t\t\t\t\t\t\t\"Quantity\": 1\n\t\t\t\t\t\t}\n\t\t\t\t\t]\n\t\t\t\t}\n\t\t\t]\n\t\t},\n\t\t\"TPA_Extensions\": {\n\t\t\t\"IntelliSellTransaction\": {\n\t\t\t\t\"RequestType\": {\n\t\t\t\t\t\"Name\": \"200ITINS\"\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{rest_endpoint}}/v2/offers/shop",
+											"host": [
+												"{{rest_endpoint}}"
+											],
+											"path": [
+												"v2",
+												"offers",
+												"shop"
+											]
+										},
+										"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max), [Resources](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/resources)</b>\n\n[//]: # \"End\""
+									},
+									"response": []
+								},
+								{
+									"name": "2. Offers Price /v1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											},
+											{
+												"key": "Conversation-ID",
+												"value": "{{conv_id}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"query\": [\n        {\n            \"offerItemId\": [\n                \"{{shop_offer_item_id}}\"\n            ]\n        }\n    ],\n    \"params\": {\n        \"formOfPayment\": [\n            {\n                \"binNumber\": \"545251\",\n                \"subCode\": \"FDA\",\n                \"cardType\" : \"MC\"\n            }\n        ]\n    }\n}\n"
+										},
+										"url": {
+											"raw": "{{rest_endpoint}}/v1/offers/price",
+											"host": [
+												"{{rest_endpoint}}"
+											],
+											"path": [
+												"v1",
+												"offers",
+												"price"
+											]
+										},
+										"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/book/offer_price), [Resources](https://developer.sabre.com/docs/rest_apis/air/book/offer_price/resources)</b>\n\n[//]: # \"End\""
+									},
+									"response": []
+								},
+								{
+									"name": "3. createBooking - ProfileId",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "Conversation-ID",
+												"type": "text",
+												"value": "{{conv_id}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\n\t\"profiles\": [ \n\t\t{\n\t\t\"uniqueId\": \"{{profileId}}\",\n\t\t\"profileTypeCode\": \"TVL\",\n\t\t\"domainId\": \"{{pcc}}\"\n\t\t}\n\t],\n\t\t\"flightOffer\": {\n\t\t\"offerId\": \"{{price_offer_id}}\",\n\t\t\"selectedOfferItems\": [\n\t\t\t\"{{price_offer_item_id}}\"\n\t\t]\n\t},\n\t\t\"travelers\": [\n\t\t{\n\t\t\t\"id\": \"{{price_passenger_id}}\"\n\t\t}\n\t]\n}"
+										},
+										"url": {
+											"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+											"host": [
+												"{{rest_endpoint}}"
+											],
+											"path": [
+												"v1",
+												"trip",
+												"orders",
+												"createBooking"
+											]
+										},
+										"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+									},
+									"response": []
+								},
+								{
+									"name": "4. Cancel Booking /v1 Cancel All",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "Conversation-ID",
+												"type": "text",
+												"value": "{{conv_id}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true\n}"
+										},
+										"url": {
+											"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+											"host": [
+												"{{rest_endpoint}}"
+											],
+											"path": [
+												"v1",
+												"trip",
+												"orders",
+												"cancelBooking"
+											]
+										},
+										"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+									},
+									"response": []
+								}
+							]
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "3 - Air Shop, Book, Cancel",
+					"item": [
+						{
+							"name": "0. REST Authorize ATK Copy",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Basic {{secret}}",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "grant_type=client_credentials"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/auth/token",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"auth",
+										"token"
+									]
+								},
+								"description": "\n\n[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/resources/getting_started_with_sabre_apis/how_to_get_a_token#3sub3)\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "1. Shop (BFM)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const itinNumber = 0;",
+											"",
+											"var jsonData = JSON.parse(responseBody);",
+											"var outboundData = jsonData.groupedItineraryResponse.scheduleDescs[0];",
+											"",
+											"",
+											"pm.environment.set(\"oFlightNumber\", outboundData.carrier.marketingFlightNumber);",
+											"pm.environment.set(\"oResBookDesigCode\", outboundData.ResBookDesigCode);",
+											"pm.environment.set(\"oDepartureTime\", outboundData.departure.time.substring(0, 5));",
+											"pm.environment.set(\"oDepartureAirport\", outboundData.departure.airport);",
+											"pm.environment.set(\"oArrivalAirport\", outboundData.arrival.airport);",
+											"pm.environment.set(\"oMarketingAirline\", outboundData.carrier.marketing);",
+											"pm.environment.set(\"oOperatingAirline\", outboundData.carrier.operating);",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"OTA_AirLowFareSearchRQ\": {\n        \"Version\": \"1\",\n        \"POS\": {\n            \"Source\": [{\n                    \"PseudoCityCode\": \"{{pcc}}\",\n                    \"RequestorID\": {\n                        \"Type\": \"1\",\n                        \"ID\": \"1\",\n                        \"CompanyName\": {\n                            \"Code\": \"TN\"\n                        }\n                    }\n                }\n            ]\n        },\n        \"OriginDestinationInformation\": [{\n                \"RPH\": \"1\",\n                \"DepartureDateTime\": \"{{start_date}}T00:00:00\",\n                \"OriginLocation\": {\n                    \"LocationCode\": \"KRK\"\n                },\n                \"DestinationLocation\": {\n                    \"LocationCode\": \"WAW\"\n                }\n            }\n        ],\n        \"TravelPreferences\": {\n            \"MaxStopsQuantity\": 0,\n            \"CabinPref\": [\n                {\n                    \"PreferLevel\": \"Preferred\",\n                    \"Cabin\": \"Y\"\n                }\n            ],\n            \"TPA_Extensions\": {\n                \"NumTrips\": {\n                    \"Number\": 10\n                },\n                \"DataSources\": {\n                    \"NDC\": \"Disable\",\n                    \"ATPCO\": \"Enable\",\n                    \"LCC\": \"Disable\"\n                }\n\n \n\n            }\n        },\n        \"TravelerInfoSummary\": {\n            \"AirTravelerAvail\": [{\n                    \"PassengerTypeQuantity\": [{\n                            \"Code\": \"ADT\",\n                            \"Quantity\": 1\n                        }\n                    ]\n                }\n            ]\n        },\n        \"TPA_Extensions\": {\n            \"IntelliSellTransaction\": {\n                \"RequestType\": {\n                    \"Name\": \"200ITINS\"\n                }\n            }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/offers/shop",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"offers",
+										"shop"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430), [Resources](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430/reference-documentation)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "2. createBooking - ATPCO payload",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": \"{{oFlightNumber}}\",\n\t\t\t\t\"airlineCode\": \"{{oMarketingAirline}}\",\n\t\t\t\t\"fromAirportCode\": \"{{oDepartureAirport}}\",\n\t\t\t\t\"toAirportCode\": \"{{oArrivalAirport}}\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"{{oDepartureTime}}\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"createBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "3. Cancel Booking /v1 Cancel All",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"cancelBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "4 - Profiles, Air Shop, Book, Cancel",
+					"item": [
+						{
+							"name": "0 - Create Profile",
+							"item": [
+								{
+									"name": "0. SessionCreateRQ (Stateful ATH) create session and prepare vars Copy",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"// Generate a unique ID for profile services\r",
+													"var uuid = require('uuid');\r",
+													"var myUUID = uuid();\r",
+													"console.log(myUUID);\r",
+													"\r",
+													"//cleanup\r",
+													"pm.environment.unset('filterName')\r",
+													"pm.environment.unset('profileName')\r",
+													"\r",
+													"pm.environment.set('filterName','CreateBookingFilter '+myUUID);\r",
+													"pm.environment.set('profileName','CreateBookingProfile '+myUUID);\r",
+													"\r",
+													"console.log(pm.environment.get('filterName'))\r",
+													"console.log(pm.environment.get('profileName'))\r",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "text/xml"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">\n    <SOAP-ENV:Header>\n        <MessageHeader xmlns=\"http://www.ebxml.org/namespaces/messageHeader\">\n            <From>\n                <PartyId>Agency</PartyId>\n            </From>\n            <To>\n                <PartyId>Sabre_API</PartyId>\n            </To>\n            <ConversationId>2019.09.DevStudio</ConversationId>\n            <Action>SessionCreateRQ</Action>\n        </MessageHeader>\n        <Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\">\n            <UsernameToken>\n                <Username>{{username}}</Username>\n                <Password>{{password}}</Password>\n                <Organization>{{pcc}}</Organization>\n                <Domain>DEFAULT</Domain>\n            </UsernameToken>\n        </Security>\n    </SOAP-ENV:Header>\n    <SOAP-ENV:Body>\n    \t\n<SessionCreateRQ returnContextID=\"true\">\n\t<POS>\n\t\t<Source PseudoCityCode=\"{{pcc}}\"/>\n\t</POS>\n</SessionCreateRQ>\n\n    </SOAP-ENV:Body>\n</SOAP-ENV:Envelope>"
+										},
+										"url": {
+											"raw": "{{soap_endpoint}}",
+											"host": [
+												"{{soap_endpoint}}"
+											]
+										},
+										"description": "Used to create stateful sessions on Sabre's Passenger Sales System\r\nAlso used to set variables for Stateful API's"
+									},
+									"response": []
+								},
+								{
+									"name": "EPS_EXT_ProfileCreateRQ (Stateful ATH) create filter",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"const xml2js = require('xml2js');\r",
+													"\r",
+													"// Parse response and remove namespaces (prefixes)\r",
+													"// Solves problem when specific APIs return different namespaces randombly ie. ns8, ns9: TP APIs\r",
+													"const parseString = xml2js.parseString;\r",
+													"const parseOptions = { tagNameProcessors: [xml2js.processors.stripPrefix] };\r",
+													"\r",
+													"parseString(responseBody, parseOptions, (err, result) => {\r",
+													"    const filterId = result.Envelope.Body[0].Sabre_OTA_ProfileCreateRS[0].Filter[0].$.FilterID;\r",
+													"    pm.environment.set('filterId', filterId);\r",
+													"});\r",
+													"\r",
+													"console.log(\"Filter id : \"+pm.environment.get('filterId'))"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"//cleanup\r",
+													"pm.environment.unset('filterId')"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "text/xml"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{header}}\r\n\r\n<Sabre_OTA_ProfileCreateRQ xmlns=\"http://www.sabre.com/eps/schemas\" Version=\"6.55\">\r\n\t<Filter CreateDateTime=\"{{start_date}}T00:00:00\" UpdateDateTime=\"{{start_date}}T00:00:00\" FilterID=\"*\" DomainID=\"{{pcc}}\" ClientCode=\"TN\" ClientContextCode=\"SBS\" FilterName=\"{{filterName}}\" FilterTypeCode=\"TVL\">\r\n\t\t<Profile>\r\n\t\t\t<TPA_Identity ClientCode=\"TN\" ClientContextCode=\"SBS\" UniqueID=\"*\" ProfileTypeCode=\"TVL\" DomainID=\"{{pcc}}\"/>\r\n\t\t\t<Traveler>\r\n\t\t\t\t<Customer>\r\n\t\t\t\t\t<PersonName InformationText=\"Info\">\r\n\t\t\t\t\t\t<GivenName>Pawel</GivenName>\r\n\t\t\t\t\t\t<SurName>Mrozicki</SurName>\r\n\t\t\t\t\t</PersonName>\r\n\t\t\t\t\t<Telephone>\r\n\t\t\t\t\t\t<FullPhoneNumber>6826051000</FullPhoneNumber>\r\n\t\t\t\t\t</Telephone>\r\n\t\t\t\t\t<Email EmailAddress=\"Test.Create.Booking@Sabre.com\"/>\r\n\t\t\t\t</Customer>\r\n\t\t\t</Traveler>\r\n\t\t</Profile>\r\n\t</Filter>\r\n</Sabre_OTA_ProfileCreateRQ>\r\n\r\n{{footer}}"
+										},
+										"url": {
+											"raw": "{{soap_endpoint}}",
+											"host": [
+												"{{soap_endpoint}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "EPS_EXT_ProfileCreateRQ (Stateful ATH) create profile",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"const xml2js = require('xml2js');\r",
+													"\r",
+													"\r",
+													"// Parse response and remove namespaces (prefixes)\r",
+													"// Solves problem when specific APIs return different namespaces randombly ie. ns8, ns9: TP APIs\r",
+													"const parseString = xml2js.parseString;\r",
+													"const parseOptions = { tagNameProcessors: [xml2js.processors.stripPrefix] };\r",
+													"\r",
+													"parseString(responseBody, parseOptions, (err, result) => {\r",
+													"    const filterId = result.Envelope.Body[0].Sabre_OTA_ProfileCreateRS[0].Profile[0].$.UniqueID;\r",
+													"    const profileName = result.Envelope.Body[0].Sabre_OTA_ProfileCreateRS[0].Profile[0].$.ProfileName;\r",
+													"    pm.environment.set('profileId', filterId);\r",
+													"    pm.environment.set('profileName', profileName);\r",
+													"});\r",
+													"\r",
+													"console.log(\"Profile id : \"+pm.environment.get('profileId'))\r",
+													"console.log(\"profileName : \"+pm.environment.get('profileName'))"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"//cleanup\r",
+													"pm.environment.unset('profileId')"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "text/xml"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{header}}\r\n\r\n<Sabre_OTA_ProfileCreateRQ xmlns=\"http://www.sabre.com/eps/schemas\" Version=\"6.55\">\r\n\t<Profile CreateDateTime=\"{{start_date}}T00:00:00\" UpdateDateTime=\"{{start_date}}T00:00:00\">\r\n\t\t<TPA_Identity ClientCode=\"TN\" ClientContextCode=\"SBS\" UniqueID=\"*\" ProfileTypeCode=\"TVL\" DomainID=\"{{pcc}}\" ProfileName=\"{{profileName}}\"/>\r\n\t\t<Traveler>\r\n\t\t\t<Customer BirthDate=\"1990-01-01\" GenderCode=\"M\">\r\n\t\t\t\t<PersonName>\r\n\t\t\t\t\t<GivenName>John</GivenName>\r\n\t\t\t\t\t\t<SurName>Smith</SurName>\r\n\t\t\t\t</PersonName>\r\n\t\t\t\t<Telephone>\r\n\t\t\t\t\t<FullPhoneNumber>6826051000</FullPhoneNumber>\r\n\t\t\t\t</Telephone>\r\n\t\t\t\t<Email EmailAddress=\"Test.Create.Booking@Sabre.com\"/>\r\n\t\t\t</Customer>\r\n\t\t\t<TPA_Extensions>\r\n\t\t\t\t<AssociatedFilters FilterID=\"{{filterId}}\" FilterName=\"{{filterName}}\" DomainID=\"{{pcc}}\" ClientCode=\"TN\" ClientContextCode=\"SBS\" CreateDateTime=\"{{start_date}}T00:00:00\" UpdateDateTime=\"{{start_date}}T00:00:00\"/>\r\n\t\t\t</TPA_Extensions>\r\n\t\t</Traveler>\r\n\t</Profile>\r\n</Sabre_OTA_ProfileCreateRQ>\r\n\r\n{{footer}}"
+										},
+										"url": {
+											"raw": "{{soap_endpoint}}",
+											"host": [
+												"{{soap_endpoint}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "SessionCloseRQ  (Stateful ATH) close session",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"//cleanup\r",
+													"pm.environment.unset('token')\r",
+													"pm.environment.unset('filterName')\r",
+													"pm.environment.unset('profileName')"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "text/xml"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{header}}\n\n<SessionCloseRQ>\n\t<POS>\n\t\t<Source PseudoCityCode=\"{{pcc}}\"/>\n\t</POS>\n</SessionCloseRQ>\n        \n{{footer}}"
+										},
+										"url": {
+											"raw": "{{soap_endpoint}}",
+											"host": [
+												"{{soap_endpoint}}"
+											]
+										},
+										"description": "Used to close stateful sessions on Sabre's Passenger Sales System"
+									},
+									"response": []
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "1 - Shop, Book, Cancel (ATPCO)",
+							"item": [
+								{
+									"name": "0. REST Authorize ATK Copy",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "noauth"
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/x-www-form-urlencoded",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Basic {{secret}}",
+												"type": "text"
+											},
+											{
+												"key": "Conversation-ID",
+												"value": "{{conv_id}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "grant_type=client_credentials"
+										},
+										"url": {
+											"raw": "{{rest_endpoint}}/v2/auth/token",
+											"host": [
+												"{{rest_endpoint}}"
+											],
+											"path": [
+												"v2",
+												"auth",
+												"token"
+											]
+										},
+										"description": "\n\n[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/resources/getting_started_with_sabre_apis/how_to_get_a_token#3sub3)\n\n[//]: # \"End\""
+									},
+									"response": []
+								},
+								{
+									"name": "1. Shop (BFM)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"const itinNumber = 0;",
+													"",
+													"var jsonData = JSON.parse(responseBody);",
+													"var outboundData = jsonData.groupedItineraryResponse.scheduleDescs[0];",
+													"",
+													"",
+													"pm.environment.set(\"oFlightNumber\", outboundData.carrier.marketingFlightNumber);",
+													"pm.environment.set(\"oResBookDesigCode\", outboundData.ResBookDesigCode);",
+													"pm.environment.set(\"oDepartureTime\", outboundData.departure.time.substring(0, 5));",
+													"pm.environment.set(\"oDepartureAirport\", outboundData.departure.airport);",
+													"pm.environment.set(\"oArrivalAirport\", outboundData.arrival.airport);",
+													"pm.environment.set(\"oMarketingAirline\", outboundData.carrier.marketing);",
+													"pm.environment.set(\"oOperatingAirline\", outboundData.carrier.operating);",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											},
+											{
+												"key": "Conversation-ID",
+												"value": "{{conv_id}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"OTA_AirLowFareSearchRQ\": {\n        \"Version\": \"1\",\n        \"POS\": {\n            \"Source\": [{\n                    \"PseudoCityCode\": \"{{pcc}}\",\n                    \"RequestorID\": {\n                        \"Type\": \"1\",\n                        \"ID\": \"1\",\n                        \"CompanyName\": {\n                            \"Code\": \"TN\"\n                        }\n                    }\n                }\n            ]\n        },\n        \"OriginDestinationInformation\": [{\n                \"RPH\": \"1\",\n                \"DepartureDateTime\": \"{{start_date}}T00:00:00\",\n                \"OriginLocation\": {\n                    \"LocationCode\": \"KRK\"\n                },\n                \"DestinationLocation\": {\n                    \"LocationCode\": \"WAW\"\n                }\n            }\n        ],\n        \"TravelPreferences\": {\n            \"MaxStopsQuantity\": 0,\n            \"TPA_Extensions\": {\n                \"NumTrips\": {\n                    \"Number\": 10\n                },\n                \"DataSources\": {\n                    \"NDC\": \"Disable\",\n                    \"ATPCO\": \"Enable\",\n                    \"LCC\": \"Disable\"\n                }\n\n \n\n            }\n        },\n        \"TravelerInfoSummary\": {\n            \"AirTravelerAvail\": [{\n                    \"PassengerTypeQuantity\": [{\n                            \"Code\": \"ADT\",\n                            \"Quantity\": 1\n                        }\n                    ]\n                }\n            ]\n        },\n        \"TPA_Extensions\": {\n            \"IntelliSellTransaction\": {\n                \"RequestType\": {\n                    \"Name\": \"200ITINS\"\n                }\n            }\n        }\n    }\n}"
+										},
+										"url": {
+											"raw": "{{rest_endpoint}}/v2/offers/shop",
+											"host": [
+												"{{rest_endpoint}}"
+											],
+											"path": [
+												"v2",
+												"offers",
+												"shop"
+											]
+										},
+										"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430), [Resources](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430/reference-documentation)</b>\n\n[//]: # \"End\""
+									},
+									"response": []
+								},
+								{
+									"name": "2. createBooking - ProfileId",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "Conversation-ID",
+												"type": "text",
+												"value": "{{conv_id}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n\t\t},\n\t\"profiles\": [ \n\t\t{\n\t\t\"uniqueId\": \"{{profileId}}\",\n\t\t\"profileTypeCode\": \"TVL\",\n\t\t\"domainId\": \"{{pcc}}\"\n\t\t}\n\t],\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": 463,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"MEL\",\n\t\t\t\t\"toAirportCode\": \"AUH\",\n\t\t\t\t\"departureDate\": \"2021-03-30\",\n\t\t\t\t\"departureTime\": \"16:55\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"flightNumber\": 462,\n\t\t\t\t\"airlineCode\": \"EY\",\n\t\t\t\t\"fromAirportCode\": \"AUH\",\n\t\t\t\t\"toAirportCode\": \"MEL\",\n\t\t\t\t\"departureDate\": \"2021-04-15\",\n\t\t\t\t\"departureTime\": \"09:00\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t]\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+											"host": [
+												"{{rest_endpoint}}"
+											],
+											"path": [
+												"v1",
+												"trip",
+												"orders",
+												"createBooking"
+											]
+										},
+										"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+									},
+									"response": []
+								},
+								{
+									"name": "3. Cancel Booking /v1 Cancel All",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "Conversation-ID",
+												"type": "text",
+												"value": "{{conv_id}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true\n}"
+										},
+										"url": {
+											"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+											"host": [
+												"{{rest_endpoint}}"
+											],
+											"path": [
+												"v1",
+												"trip",
+												"orders",
+												"cancelBooking"
+											]
+										},
+										"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+									},
+									"response": []
+								}
+							]
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "5 - Air LCC Shop, Book, Cancel",
+					"item": [
+						{
+							"name": "0. REST Authorize ATK Copy",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Basic {{secret}}",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "grant_type=client_credentials"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/auth/token",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"auth",
+										"token"
+									]
+								},
+								"description": "\n\n[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/resources/getting_started_with_sabre_apis/how_to_get_a_token#3sub3)\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "1. Shop (BFM)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const itinNumber = 0;",
+											"",
+											"var jsonData = JSON.parse(responseBody);",
+											"var outboundData = jsonData.groupedItineraryResponse.scheduleDescs[0];",
+											"",
+											"",
+											"pm.environment.set(\"oFlightNumber\", outboundData.carrier.marketingFlightNumber);",
+											"pm.environment.set(\"oResBookDesigCode\", outboundData.ResBookDesigCode);",
+											"pm.environment.set(\"oDepartureTime\", outboundData.departure.time.substring(0, 5));",
+											"pm.environment.set(\"oDepartureAirport\", outboundData.departure.airport);",
+											"pm.environment.set(\"oArrivalAirport\", outboundData.arrival.airport);",
+											"pm.environment.set(\"oMarketingAirline\", outboundData.carrier.marketing);",
+											"pm.environment.set(\"oOperatingAirline\", outboundData.carrier.operating);",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"OTA_AirLowFareSearchRQ\": {\n        \"Version\": \"1\",\n        \"POS\": {\n            \"Source\": [{\n                    \"PseudoCityCode\": \"{{pcc}}\",\n                    \"RequestorID\": {\n                        \"Type\": \"1\",\n                        \"ID\": \"1\",\n                        \"CompanyName\": {\n                            \"Code\": \"TN\"\n                        }\n                    }\n                }\n            ]\n        },\n        \"OriginDestinationInformation\": [{\n                \"RPH\": \"1\",\n                \"DepartureDateTime\": \"{{start_date}}T00:00:00\",\n                \"OriginLocation\": {\n                    \"LocationCode\": \"KRK\"\n                },\n                \"DestinationLocation\": {\n                    \"LocationCode\": \"STN\"\n                }\n            }\n        ],\n        \"TravelPreferences\": {\n\t\t\t\"VendorPref\": [\n\t\t\t\t{\n\t\t\t\t\t\"Code\" : \"FR\"\n\t\t\t\t}\n\t\t\t],\n            \"TPA_Extensions\": {\n                \"NumTrips\": {\n                    \"Number\": 10\n                },\n                \"DataSources\": {\n                    \"NDC\": \"Disable\",\n                    \"ATPCO\": \"Disable\",\n                    \"LCC\": \"Enable\"\n                },\n                 \"PreferNDCSourceOnTie\": {\n                    \"Value\": true\n                }\n\n \n\n            }\n        },\n        \"TravelerInfoSummary\": {\n            \"AirTravelerAvail\": [{\n                    \"PassengerTypeQuantity\": [{\n                            \"Code\": \"ADT\",\n                            \"Quantity\": 1\n                        }\n                    ]\n                }\n            ]\n        },\n        \"TPA_Extensions\": {\n            \"IntelliSellTransaction\": {\n                \"RequestType\": {\n                    \"Name\": \"200ITINS\"\n                }\n            }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/offers/shop",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"offers",
+										"shop"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430), [Resources](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430/reference-documentation)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "2. createBooking - LCC",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\"\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": \"{{oFlightNumber}}\",\n\t\t\t\t\"airlineCode\": \"{{oMarketingAirline}}\",\n\t\t\t\t\"fromAirportCode\": \"{{oDepartureAirport}}\",\n\t\t\t\t\"toAirportCode\": \"{{oArrivalAirport}}\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"{{oDepartureTime}}\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\",\n                \"source\": \"LCC\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"createBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "3. Cancel Booking /v1 Cancel All",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"cancelBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "6 - Air Shop, Book, Fulfill, Cancel + Void",
+					"item": [
+						{
+							"name": "0. REST Authorize ATK Copy",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Basic {{secret}}",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "grant_type=client_credentials"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/auth/token",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"auth",
+										"token"
+									]
+								},
+								"description": "\n\n[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/resources/getting_started_with_sabre_apis/how_to_get_a_token#3sub3)\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "1. Shop (BFM)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const itinNumber = 0;",
+											"",
+											"var jsonData = JSON.parse(responseBody);",
+											"var outboundData = jsonData.groupedItineraryResponse.scheduleDescs[0];",
+											"",
+											"",
+											"pm.environment.set(\"oFlightNumber\", outboundData.carrier.marketingFlightNumber);",
+											"pm.environment.set(\"oResBookDesigCode\", outboundData.ResBookDesigCode);",
+											"pm.environment.set(\"oDepartureTime\", outboundData.departure.time.substring(0, 5));",
+											"pm.environment.set(\"oDepartureAirport\", outboundData.departure.airport);",
+											"pm.environment.set(\"oArrivalAirport\", outboundData.arrival.airport);",
+											"pm.environment.set(\"oMarketingAirline\", outboundData.carrier.marketing);",
+											"pm.environment.set(\"oOperatingAirline\", outboundData.carrier.operating);",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"OTA_AirLowFareSearchRQ\": {\n        \"Version\": \"1\",\n        \"POS\": {\n            \"Source\": [{\n                    \"PseudoCityCode\": \"{{pcc}}\",\n                    \"RequestorID\": {\n                        \"Type\": \"1\",\n                        \"ID\": \"1\",\n                        \"CompanyName\": {\n                            \"Code\": \"TN\"\n                        }\n                    }\n                }\n            ]\n        },\n        \"OriginDestinationInformation\": [{\n                \"RPH\": \"1\",\n                \"DepartureDateTime\": \"{{start_date}}T00:00:00\",\n                \"OriginLocation\": {\n                    \"LocationCode\": \"DFW\"\n                },\n                \"DestinationLocation\": {\n                    \"LocationCode\": \"TUL\"\n                }\n            }\n        ],\n        \"TravelPreferences\": {\n            \"MaxStopsQuantity\": 0,\n            \"TPA_Extensions\": {\n                \"NumTrips\": {\n                    \"Number\": 10\n                },\n                \"DataSources\": {\n                    \"NDC\": \"Disable\",\n                    \"ATPCO\": \"Enable\",\n                    \"LCC\": \"Disable\"\n                }\n\n \n\n            }\n        },\n        \"TravelerInfoSummary\": {\n            \"AirTravelerAvail\": [{\n                    \"PassengerTypeQuantity\": [{\n                            \"Code\": \"ADT\",\n                            \"Quantity\": 1\n                        }\n                    ]\n                }\n            ]\n        },\n        \"TPA_Extensions\": {\n            \"IntelliSellTransaction\": {\n                \"RequestType\": {\n                    \"Name\": \"200ITINS\"\n                }\n            }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/offers/shop",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"offers",
+										"shop"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430), [Resources](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430/reference-documentation)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "2. createBooking - ATPCO payload",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Smith\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n            \"identityDocuments\": [\n            {\n                \"documentNumber\": \"0123456789\",\n                \"documentType\": \"PASSPORT\",\n                \"expiryDate\": \"2024-07-09\",\n                \"issuingCountryCode\": \"US\",\n                \"residenceCountryCode\": \"US\",\n                \"givenName\": \"John\",\n                \"middleName\": \"Jack\",\n                \"surname\": \"Smith\",\n                \"birthDate\": \"1980-12-02\",\n                \"gender\": \"MALE\"\n            }\n            ]\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": \"{{oFlightNumber}}\",\n\t\t\t\t\"airlineCode\": \"{{oMarketingAirline}}\",\n\t\t\t\t\"fromAirportCode\": \"{{oDepartureAirport}}\",\n\t\t\t\t\"toAirportCode\": \"{{oArrivalAirport}}\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"{{oDepartureTime}}\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"createBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "3. airTicket",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"response is ok\", function () {\r",
+											"    pm.response.to.be.ok;\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"response must be valid and have a body\", function () {\r",
+											"    // this assertion also checks if a body  exists\r",
+											"     pm.response.to.be.json; \r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "accept",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"AirTicketRQ\": {\n        \"DesignatePrinter\": {\n            \"Printers\": {\n                \"Ticket\": {\n                    \"CountryCode\": \"AT\"\n                }\n            }\n        },\n        \"Itinerary\": {\n            \"ID\": \"{{pnr}}\"\n        },\n        \"Ticketing\": [\n            {\n                \"FOP_Qualifiers\": {\n                    \"BasicFOP\": {\n                        \"Type\": \"CA\"\n                    }\n                }\n            }\n        ],\n        \"PostProcessing\": {\n            \"EndTransaction\": {\n                \"Source\": {\n                    \"ReceivedFrom\": \"API TEST\"\n                }\n            }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1.2.0/air/ticket",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1.2.0",
+										"air",
+										"ticket"
+									]
+								},
+								"description": "### <br>"
+							},
+							"response": []
+						},
+						{
+							"name": "4. GetBooking  - Display",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"confirmationId\": \"{{pnr}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"getBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "5. Cancel Booking /v1 Cancel All + VOID tickets",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true,\n    \"flightTicketOperation\": \"VOID\",\n    \"errorHandlingPolicy\": \"ALLOW_PARTIAL_CANCEL\"\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"cancelBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "6. GetBooking  - Display",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"confirmationId\": \"{{pnr}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"getBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "7 - Air Shop, Book, Fulfill, Void, Display, Cancel",
+					"item": [
+						{
+							"name": "0. REST Authorize ATK Copy",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Basic {{secret}}",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "grant_type=client_credentials"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/auth/token",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"auth",
+										"token"
+									]
+								},
+								"description": "\n\n[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/resources/getting_started_with_sabre_apis/how_to_get_a_token#3sub3)\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "1. Shop (BFM)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const itinNumber = 0;",
+											"",
+											"var jsonData = JSON.parse(responseBody);",
+											"var outboundData = jsonData.groupedItineraryResponse.scheduleDescs[0];",
+											"",
+											"",
+											"pm.environment.set(\"oFlightNumber\", outboundData.carrier.marketingFlightNumber);",
+											"pm.environment.set(\"oResBookDesigCode\", outboundData.ResBookDesigCode);",
+											"pm.environment.set(\"oDepartureTime\", outboundData.departure.time.substring(0, 5));",
+											"pm.environment.set(\"oDepartureAirport\", outboundData.departure.airport);",
+											"pm.environment.set(\"oArrivalAirport\", outboundData.arrival.airport);",
+											"pm.environment.set(\"oMarketingAirline\", outboundData.carrier.marketing);",
+											"pm.environment.set(\"oOperatingAirline\", outboundData.carrier.operating);",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"OTA_AirLowFareSearchRQ\": {\n        \"Version\": \"2\",\n        \"POS\": {\n            \"Source\": [{\n                    \"PseudoCityCode\": \"{{pcc}}\",\n                    \"RequestorID\": {\n                        \"Type\": \"1\",\n                        \"ID\": \"1\",\n                        \"CompanyName\": {\n                            \"Code\": \"TN\"\n                        }\n                    }\n                }\n            ]\n        },\n        \"OriginDestinationInformation\": [{\n                \"RPH\": \"1\",\n                \"DepartureDateTime\": \"{{start_date}}T00:00:00\",\n                \"OriginLocation\": {\n                    \"LocationCode\": \"YVR\"\n                },\n                \"DestinationLocation\": {\n                    \"LocationCode\": \"YYC\"\n                }\n            }\n        ],\n        \"TravelPreferences\": {\n                \"MaxStopsQuantity\": 0, \n            \t\t\t\"VendorPref\": [\n\t\t\t\t{\n\t\t\t\t\t\"Code\" : \"AC\"\n\t\t\t\t}\n\t\t\t],\n            \"TPA_Extensions\": {\n                \"NumTrips\": {\n                    \"Number\": 10\n                },\n                \"DataSources\": {\n                    \"NDC\": \"Disable\",\n                    \"ATPCO\": \"Enable\",\n                    \"LCC\": \"Disable\"\n                }\n\n \n\n            }\n        },\n        \"TravelerInfoSummary\": {\n            \"AirTravelerAvail\": [{\n                    \"PassengerTypeQuantity\": [{\n                            \"Code\": \"ADT\",\n                            \"Quantity\": 1\n                        }\n                    ]\n                }\n\n            ]\n        },\n        \"TPA_Extensions\": {\n            \"IntelliSellTransaction\": {\n                \"RequestType\": {\n                    \"Name\": \"200ITINS\"\n                }\n            }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/offers/shop",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"offers",
+										"shop"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430), [Resources](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430/reference-documentation)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "2. createBooking",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n            \"identityDocuments\": [\n            {\n                \"documentNumber\": \"0123456789\",\n                \"documentType\": \"PASSPORT\",\n                \"expiryDate\": \"2024-07-09\",\n                \"issuingCountryCode\": \"US\",\n                \"residenceCountryCode\": \"US\",\n                \"givenName\": \"John\",\n                \"middleName\": \"Jack\",\n                \"surname\": \"Kowalski\",\n                \"birthDate\": \"1970-01-23\",\n                \"gender\": \"MALE\"\n            }\n            ]\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Mrozicki\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n            \"identityDocuments\": [\n            {\n                \"documentNumber\": \"0123456789\",\n                \"documentType\": \"PASSPORT\",\n                \"expiryDate\": \"2024-07-09\",\n                \"issuingCountryCode\": \"US\",\n                \"residenceCountryCode\": \"US\",\n                \"givenName\": \"All\",\n                \"middleName\": \"Jack\",\n                \"surname\": \"Mrozicki\",\n                \"birthDate\": \"2000-01-23\",\n                \"gender\": \"MALE\"\n            }\n            ]\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": \"{{oFlightNumber}}\",\n\t\t\t\t\"airlineCode\": \"{{oMarketingAirline}}\",\n\t\t\t\t\"fromAirportCode\": \"{{oDepartureAirport}}\",\n\t\t\t\t\"toAirportCode\": \"{{oArrivalAirport}}\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"{{oDepartureTime}}\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"createBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "3. airTicket",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"response is ok\", function () {\r",
+											"    pm.response.to.be.ok;\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"response must be valid and have a body\", function () {\r",
+											"    // this assertion also checks if a body  exists\r",
+											"     pm.response.to.be.json; \r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "accept",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"AirTicketRQ\": {\n        \"DesignatePrinter\": {\n            \"Printers\": {\n                \"Ticket\": {\n                    \"CountryCode\": \"AT\"\n                }\n            }\n        },\n        \"Itinerary\": {\n            \"ID\": \"{{pnr}}\"\n        },\n        \"Ticketing\": [\n            {\n                \"FOP_Qualifiers\": {\n                    \"BasicFOP\": {\n                        \"Type\": \"CA\"\n                    }\n                }\n            }\n        ],\n        \"PostProcessing\": {\n            \"EndTransaction\": {\n                \"Source\": {\n                    \"ReceivedFrom\": \"API TEST\"\n                }\n            }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1.2.0/air/ticket",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1.2.0",
+										"air",
+										"ticket"
+									]
+								},
+								"description": "### <br>"
+							},
+							"response": []
+						},
+						{
+							"name": "4. GetBooking  - Display",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"",
+											"pm.environment.set(\"ticket1\", jsonData.flightTickets[0].number);",
+											"pm.environment.set(\"ticket2\", jsonData.flightTickets[1].number);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"confirmationId\": \"{{pnr}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"getBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "5. Check Flight Tickets",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"tickets\": [\n      {\n        \"number\": \"{{ticket1}}\"\n      },\n      {\n        \"number\": \"{{ticket2}}\"\n      }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/checkFlightTickets",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"checkFlightTickets"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "6. Void Flight Tickets - with ALLOW_PARTIAL_CANCEL",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"tickets\": [\n    \"{{ticket1}}\",\n    \"{{ticket2}}\"\n  ],\n  \"errorHandlingPolicy\": \"ALLOW_PARTIAL_CANCEL\"  \n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/voidFlightTickets",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"voidFlightTickets"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "7. GetBooking  - Display Flight Tickets only",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"confirmationId\": \"{{pnr}}\",\r\n    \"returnOnly\":\r\n  [ \"TICKETS\"]\r\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"getBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "8. Cancel Booking /v1 Cancel All",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"cancelBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "8 - Air Shop, Book, Fulfill, Refund, Display, Cancel",
+					"item": [
+						{
+							"name": "0. REST Authorize ATK Copy",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Basic {{secret}}",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "grant_type=client_credentials"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/auth/token",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"auth",
+										"token"
+									]
+								},
+								"description": "\n\n[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/resources/getting_started_with_sabre_apis/how_to_get_a_token#3sub3)\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "1. Shop (BFM)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const itinNumber = 0;",
+											"",
+											"var jsonData = JSON.parse(responseBody);",
+											"var outboundData = jsonData.groupedItineraryResponse.scheduleDescs[0];",
+											"",
+											"",
+											"pm.environment.set(\"oFlightNumber\", outboundData.carrier.marketingFlightNumber);",
+											"pm.environment.set(\"oResBookDesigCode\", outboundData.ResBookDesigCode);",
+											"pm.environment.set(\"oDepartureTime\", outboundData.departure.time.substring(0, 5));",
+											"pm.environment.set(\"oDepartureAirport\", outboundData.departure.airport);",
+											"pm.environment.set(\"oArrivalAirport\", outboundData.arrival.airport);",
+											"pm.environment.set(\"oMarketingAirline\", outboundData.carrier.marketing);",
+											"pm.environment.set(\"oOperatingAirline\", outboundData.carrier.operating);",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Conversation-ID",
+										"value": "{{conv_id}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"OTA_AirLowFareSearchRQ\": {\n        \"Version\": \"2\",\n        \"POS\": {\n            \"Source\": [{\n                    \"PseudoCityCode\": \"{{pcc}}\",\n                    \"RequestorID\": {\n                        \"Type\": \"1\",\n                        \"ID\": \"1\",\n                        \"CompanyName\": {\n                            \"Code\": \"TN\"\n                        }\n                    }\n                }\n            ]\n        },\n        \"OriginDestinationInformation\": [{\n                \"RPH\": \"1\",\n                \"DepartureDateTime\": \"{{start_date}}T00:00:00\",\n                \"OriginLocation\": {\n                    \"LocationCode\": \"YVR\"\n                },\n                \"DestinationLocation\": {\n                    \"LocationCode\": \"YYC\"\n                }\n            }\n        ],\n        \"TravelPreferences\": {\n                \"MaxStopsQuantity\": 0, \n            \t\t\t\"VendorPref\": [\n\t\t\t\t{\n\t\t\t\t\t\"Code\" : \"AC\"\n\t\t\t\t}\n\t\t\t],\n            \"TPA_Extensions\": {\n                \"NumTrips\": {\n                    \"Number\": 10\n                },\n                \"DataSources\": {\n                    \"NDC\": \"Disable\",\n                    \"ATPCO\": \"Enable\",\n                    \"LCC\": \"Disable\"\n                }\n\n \n\n            }\n        },\n        \"TravelerInfoSummary\": {\n            \"AirTravelerAvail\": [{\n                    \"PassengerTypeQuantity\": [{\n                            \"Code\": \"ADT\",\n                            \"Quantity\": 1\n                        }\n                    ]\n                }\n\n            ]\n        },\n        \"TPA_Extensions\": {\n            \"IntelliSellTransaction\": {\n                \"RequestType\": {\n                    \"Name\": \"200ITINS\"\n                }\n            }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v2/offers/shop",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v2",
+										"offers",
+										"shop"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430), [Resources](https://developer.sabre.com/docs/rest_apis/air/search/bargain_finder_max/versions/v430/reference-documentation)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "2. createBooking",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t \"agency\": {\n\t\t\"address\": {\n\t\t\t\"name\": \"John Smith\",\n\t\t\t\"street\": \"1230 Ellen Ave, apt 10\",\n\t\t\t\"city\": \"Dallas\",\n\t\t\t\"stateProvince\": \"TX\",\n\t\t\t\"postalCode\": \"75063\",\n\t\t\t\"countryCode\": \"US\",\n\t\t\t\"freeText\": \"John Smith\\n1230 Ellen Ave, apt 10\\nDallas, TX 75063\\nUS\"\n\t\t},\n\t\t\"agencyCustomerNumber\": \"1234567\",\n\t\t\"ticketingPolicy\": \"TODAY\"\n  \t},\n\t\"travelers\": [\n\t\t{\n\t\t\t\"givenName\": \"John\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"1970-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n            \"identityDocuments\": [\n            {\n                \"documentNumber\": \"0123456789\",\n                \"documentType\": \"PASSPORT\",\n                \"expiryDate\": \"2024-07-09\",\n                \"issuingCountryCode\": \"US\",\n                \"residenceCountryCode\": \"US\",\n                \"givenName\": \"John\",\n                \"middleName\": \"Jack\",\n                \"surname\": \"Kowalski\",\n                \"birthDate\": \"1980-12-02\",\n                \"gender\": \"MALE\"\n            }\n            ]\n\t\t},\n        {\n\t\t\t\"givenName\": \"All\",\n\t\t\t\"surname\": \"Kowalski\",\n\t\t\t\"birthDate\": \"2000-01-23\",\n\t\t\t\"passengerCode\": \"ADT\",\n            \"identityDocuments\": [\n            {\n                \"documentNumber\": \"01234567890\",\n                \"documentType\": \"PASSPORT\",\n                \"expiryDate\": \"2024-07-09\",\n                \"issuingCountryCode\": \"US\",\n                \"residenceCountryCode\": \"US\",\n                \"givenName\": \"All\",\n                \"middleName\": \"Jack\",\n                \"surname\": \"Kowalski\",\n                \"birthDate\": \"1980-12-02\",\n                \"gender\": \"MALE\"\n            }\n            ]\n\t\t}\n\t],\n\t\"contactInfo\":\n    {\n      \"emails\": [\n        \"travel@sabre.com\",\n\t\t\"travel2@sabre.com\"\n      ],\n      \"phones\": [\n        \"+123456\"\n      ]\n    },\n\t\"flightDetails\": {\n\t\t\"flights\": [\n\t\t\t{\n\t\t\t\t\"flightNumber\": \"{{oFlightNumber}}\",\n\t\t\t\t\"airlineCode\": \"{{oMarketingAirline}}\",\n\t\t\t\t\"fromAirportCode\": \"{{oDepartureAirport}}\",\n\t\t\t\t\"toAirportCode\": \"{{oArrivalAirport}}\",\n\t\t\t\t\"departureDate\": \"{{start_date}}\",\n\t\t\t\t\"departureTime\": \"{{oDepartureTime}}\",\n\t\t\t\t\"bookingClass\": \"Y\",\n\t\t\t\t\"marriageGroup\": false,\n\t\t\t\t\"flightStatusCode\": \"NN\"\n\t\t\t}\n\t\t],\n        \"flightPricing\": [\n        {\n        }\n    ]\n\t},\n    \"payment\": {\n        \"billingAddress\": {\n        \"name\": \"John Smith\",\n        \"street\": \"1230 Ellen Ave, apt 10\",\n        \"city\": \"Dallas\",\n        \"stateProvince\": \"TX\",\n        \"postalCode\": \"75063\",\n        \"countryCode\": \"US\"\n        }\n  } \n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/createBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"createBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "3. airTicket",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"response is ok\", function () {\r",
+											"    pm.response.to.be.ok;\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"response must be valid and have a body\", function () {\r",
+											"    // this assertion also checks if a body  exists\r",
+											"     pm.response.to.be.json; \r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "accept",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"AirTicketRQ\": {\n        \"DesignatePrinter\": {\n            \"Printers\": {\n                \"Ticket\": {\n                    \"CountryCode\": \"AT\"\n                }\n            }\n        },\n        \"Itinerary\": {\n            \"ID\": \"{{pnr}}\"\n        },\n        \"Ticketing\": [\n            {\n                \"FOP_Qualifiers\": {\n                    \"BasicFOP\": {\n                        \"Type\": \"CA\"\n                    }\n                }\n            }\n        ],\n        \"PostProcessing\": {\n            \"EndTransaction\": {\n                \"Source\": {\n                    \"ReceivedFrom\": \"API TEST\"\n                }\n            }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1.2.0/air/ticket",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1.2.0",
+										"air",
+										"ticket"
+									]
+								},
+								"description": "### <br>"
+							},
+							"response": []
+						},
+						{
+							"name": "4. GetBooking  - Display",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"",
+											"pm.environment.set(\"ticket1\", jsonData.flightTickets[0].number);",
+											"pm.environment.set(\"ticket2\", jsonData.flightTickets[1].number);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"confirmationId\": \"{{pnr}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"getBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "5. Check Flight Tickets",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"tickets\": [\n      {\n        \"number\": \"{{ticket1}}\"\n      },\n      {\n        \"number\": \"{{ticket2}}\"\n      }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/checkFlightTickets",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"checkFlightTickets"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "5. Refund Flight Tickets",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"tickets\": [\n      {\n        \"number\": \"{{ticket1}}\"\n      },\n      {\n        \"number\": \"{{ticket2}}\"\n      }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/refundFlightTickets",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"refundFlightTickets"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "6. GetBooking  - Display Flight Tickets only",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"confirmationId\": \"{{pnr}}\",\r\n    \"returnOnly\":\r\n  [ \"TICKETS\"]\r\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/getBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"getBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						},
+						{
+							"name": "7. Cancel Booking /v1 Cancel All",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Conversation-ID",
+										"type": "text",
+										"value": "{{conv_id}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"confirmationId\": \"{{pnr}}\",\n    \"retrieveBooking\": true,\n    \"cancelAll\": true,\n    \"errorHandlingPolicy\": \"ALLOW_PARTIAL_CANCEL\"\n}"
+								},
+								"url": {
+									"raw": "{{rest_endpoint}}/v1/trip/orders/cancelBooking",
+									"host": [
+										"{{rest_endpoint}}"
+									],
+									"path": [
+										"v1",
+										"trip",
+										"orders",
+										"cancelBooking"
+									]
+								},
+								"description": "[//]: # \"Start\"\n\n<b>[Description](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management), [Resources](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/reference-documentation), [Help](https://developer.sabre.com/docs/rest_apis/trip/orders/booking_management/help)</b>\n\n[//]: # \"End\""
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{token}}",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"",
+					"",
+					"// Get the first string of the URI",
+					"const URI = request.url.split(\"/\")[0];",
+					"",
+					"// Postman doesn't define a variable until the request is sent, therefore the URI is either:",
+					"// {{rest_endpoint}}/xx/yy/zz or {{soap_endpoint}}",
+					"",
+					"",
+					"// Capture today's date",
+					"var moment = require('moment');",
+					"// Add 30 days to today's date and use this date in start_date",
+					"const today = moment().format(\"YYYY-MM-DD\");",
+					"pm.environment.set('today', today);",
+					"// Add 30 days to today's date and use this date in start_date",
+					"const start_date = moment().add(30, 'day').format(\"YYYY-MM-DD\");",
+					"pm.environment.set('start_date', start_date);",
+					"// Add 37 days to today's date and use this date in end_date",
+					"const end_date = moment().add(37, 'day').format(\"YYYY-MM-DD\");",
+					"pm.environment.set('end_date', end_date);",
+					"// Add 33 days to today's date and use this date in short_end_date (primarily for hotel search)",
+					"const short_end_date = moment().add(33, 'day').format(\"YYYY-MM-DD\");",
+					"pm.environment.set('short_end_date', short_end_date);",
+					"",
+					"pm.environment.set('conv_id', \"2021.01.DevStudio\");",
+					"",
+					"// Analyze 'token' variable, if it starts with \"ATH:\" this text is removed as it's not accepted by Sabre's 2SG gateways ",
+					"var token = pm.variables.get('token');",
+					"// Evaluate if token is defined or not null, and only then attempt to remove the ATH prefix",
+					"if (token) {",
+					"    pm.environment.set('token', token.replace(/^ATH:/, ''));",
+					"}",
+					"",
+					"if ((URI) == ('{{soap_endpoint}}')) {",
+					"",
+					"    //***SOAP Path***//",
+					"    //This means that the temp URL is: {{soap_endpoint}}",
+					"",
+					"    // Get service action code from request name and ignore the following prefixes if present:",
+					"    // underscore (_)",
+					"    // number & dot (1.)",
+					"    // these variations are used in different examples across this collection",
+					"    const action = request.name.split(' ')[0].replace(/^_|[0-9]./, '');",
+					"",
+					"",
+					"    // Add the token value into the token variable",
+					"    const token = pm.variables.get('token');",
+					"",
+					"    // Add the ApplicationId value into the AppId variable",
+					"    const AppId = pm.variables.get('AppId');",
+					"",
+					"    // All SOAP API calls require a header section, we have created this variable to remove it from the \"working\" message and ensure the user can focus on the payload section ",
+					"",
+					"    const header_appid = `<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Header><MessageHeader xmlns=\"http://www.ebxml.org/namespaces/messageHeader\"><From><PartyId>Agency</PartyId></From><To><PartyId>SWS</PartyId></To><ConversationId>2021.01.DevStudio</ConversationId><Action>${action}</Action><CustomerAppId xmlns:ns10=\"http://webservices.sabre.com/\">${AppId}</CustomerAppId></MessageHeader><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\"><BinarySecurityToken>${token}</BinarySecurityToken></Security></SOAP-ENV:Header><SOAP-ENV:Body>`;",
+					"",
+					"    const header_diag = `<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Header><MessageHeader xmlns=\"http://www.ebxml.org/namespaces/messageHeader\"><From><PartyId>Agency</PartyId></From><To><PartyId>SWS</PartyId></To><ConversationId>2021.01.DevStudio</ConversationId><Action>${action}</Action></MessageHeader><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\"><BinarySecurityToken>${token}</BinarySecurityToken></Security><Diagnostics xmlns=\"http://webservices.sabre.com\"/></SOAP-ENV:Header><SOAP-ENV:Body>`;",
+					"",
+					"    const header = `<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Header><MessageHeader xmlns=\"http://www.ebxml.org/namespaces/messageHeader\"><From><PartyId>Agency</PartyId></From><To><PartyId>SWS</PartyId></To><ConversationId>2021.01.DevStudio</ConversationId><Action>${action}</Action></MessageHeader><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\"><BinarySecurityToken EncodingType=\"Base64Binary\" valueType=\"String\">${token}</BinarySecurityToken></Security></SOAP-ENV:Header><SOAP-ENV:Body>`;",
+					"",
+					"",
+					"",
+					"    // Same as previous item, this footer variable is used to close the entire SOAP envelope",
+					"    const footer = '</SOAP-ENV:Body></SOAP-ENV:Envelope>';",
+					"",
+					"    // Add header & footer variables into the specific variables",
+					"    pm.variables.set('header_appid', header_appid);",
+					"    pm.variables.set('header', header);",
+					"    pm.variables.set('header_diag', header_diag);",
+					"    pm.variables.set('footer', footer);",
+					"",
+					"",
+					"} else if ((URI) == ('{{rest_endpoint}}')) {",
+					"",
+					"    //***REST Path***//",
+					"    //This means that the temp URL is: {{rest_endpoint}}/xx/yy/zz",
+					"",
+					"    // Capture URI element which identifies the API method",
+					"    const URI_ID = request.url.split(\"/\")[3];",
+					"",
+					"",
+					"",
+					"    switch (URI_ID) {",
+					"",
+					"        case 'token':",
+					"            // Capture username",
+					"            const username = pm.variables.get('username');",
+					"            // Capture PCC",
+					"            const pcc = pm.variables.get('pcc');",
+					"",
+					"            if ((request.url.split(\"/\")[1]) == ('v2')) {",
+					"",
+					"                // Construct raw client id (by appending V1:username:PCC:AA)",
+					"                const clientidRaw = `V1:${username}:${pcc}:AA`;",
+					"                // Base64 encode the previous string",
+					"                const clientidArray = CryptoJS.enc.Utf8.parse(clientidRaw);",
+					"                const clientidBase64 = CryptoJS.enc.Base64.stringify(clientidArray);",
+					"                // Capture password",
+					"                const passwordRaw = pm.variables.get('password');",
+					"                // Base64 enconde the password",
+					"                const passwordArray = CryptoJS.enc.Utf8.parse(passwordRaw);",
+					"                const passwordBase64 = CryptoJS.enc.Base64.stringify(passwordArray);",
+					"                // Combine the two previous strings with a : in the middle",
+					"                const secretRaw = `${clientidBase64}:${passwordBase64}`;",
+					"                // Base64 enconde this last string",
+					"                const secretArray = CryptoJS.enc.Utf8.parse(secretRaw);",
+					"                const secretBase64 = CryptoJS.enc.Base64.stringify(secretArray);",
+					"                // Set the secret variable with the latest encoded string",
+					"                pm.environment.set('secret', secretBase64);",
+					"                pm.environment.set('token', \"\");",
+					"",
+					"            } else {",
+					"                // Assumption is that this is /v3/auth/token or higher version",
+					"                // Catpure client ID",
+					"                const client_id = pm.variables.get('client_id');",
+					"                // Capture client secret",
+					"                const client_secret = pm.variables.get('client_secret');",
+					"                // Combine client_id + client_secret (by appending client_id:client_secret)",
+					"                const clientIDClientSecret = `${client_id}:${client_secret}`;",
+					"                // Base64 encode the previous string",
+					"                const clientIDClientSecretArray = CryptoJS.enc.Utf8.parse(clientIDClientSecret);",
+					"                const clientIDClientSecretBase64 = CryptoJS.enc.Base64.stringify(clientIDClientSecretArray);",
+					"                // Set the secret variable with the latest encoded string",
+					"                pm.environment.set('auth_secret', clientIDClientSecretBase64);",
+					"                pm.environment.set('token', \"\");   ",
+					"            }",
+					"",
+					"            break;",
+					"",
+					"        case 'shop':",
+					"",
+					"            break;",
+					"    }",
+					"}",
+					"",
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"",
+					"// Logic to ensure that any potential / at the end of the request url would not impact the matching logic to determine if a request is being sent to Sabre's REST or SOAP endpoint.",
+					"// Some Postman versions automatically append a / at the end of the request url, so if identified it gets removed",
+					"var requestURL = request.url;",
+					"if (requestURL.charAt(requestURL.length-1) == \"/\") {",
+					"    requestURL = requestURL.substring(0, requestURL.length - 1);",
+					"}",
+					"",
+					"// Only execute the following code for SOAP APIs (based on the endpoint being used)",
+					"if (((request.url) == (pm.environment.get(\"soap_endpoint\"))) || ((requestURL) == (pm.environment.get(\"soap_endpoint\")))){",
+					"",
+					"    //***SOAP Path***//",
+					"",
+					"    const xml2js = require('xml2js');",
+					"",
+					"    // Get service action name from request name and ignore leading underscore if present",
+					"    const action = request.name.split(' ')[0].replace(/^_/, '');",
+					"",
+					"    // Parse response and remove namespaces (prefixes)",
+					"    // Solves problem when specific APIs return different namespaces randombly ie. ns8, ns9: TP APIs",
+					"    const parseString = xml2js.parseString;",
+					"    const parseOptions = { tagNameProcessors: [xml2js.processors.stripPrefix] };",
+					"",
+					"    switch (action) {",
+					"        case 'SessionCreateRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const token = result.Envelope.Header[0].Security[0].BinarySecurityToken[0]._;",
+					"                pm.environment.set('token', \"\");",
+					"                pm.environment.set('token', token);",
+					"            });",
+					"            break;",
+					"        case 'TokenCreateRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const token = result.Envelope.Header[0].Security[0].BinarySecurityToken[0]._;",
+					"                pm.environment.set('token', \"\");",
+					"                pm.environment.set('token', token);",
+					"            });",
+					"            break;",
+					"        case 'ContextChangeLLSRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const token = result.Envelope.Body[0].ContextChangeRS[0].SecurityToken[0];",
+					"                if ((token.$.Updated) == ('true')) {",
+					"                    pm.environment.set('token', \"\");",
+					"                    pm.environment.set('token', token._);",
+					"                }",
+					"            });",
+					"            break;",
+					"        case 'CreatePassengerNameRecordRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const pnr = result.Envelope.Body[0].CreatePassengerNameRecordRS[0].ItineraryRef[0].$.ID;",
+					"                pm.environment.set('pnr', pnr);",
+					"            });",
+					"            break;",
+					"        case 'EnhancedEndTransactionRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const pnr = result.Envelope.Body[0].EnhancedEndTransactionRS[0].ItineraryRef[0].$.ID;",
+					"                pm.environment.set('pnr', pnr);",
+					"            });",
+					"            break;",
+					"        case 'AirTicketRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const summary = result.Envelope.Body[0].AirTicketRS[0].Summary;",
+					"                summary.forEach((tktDoc, i) => {",
+					"                    const tktNum = 'tkt' + (i === 0 ? '' : i + 1);",
+					"                    const tktDateTime = tktDoc.LocalIssueDateTime[0];",
+					"                    const tktDate = tktDateTime.substring(tktDateTime, tktDateTime.indexOf('T'));",
+					"                    pm.environment.set(tktNum, tktDoc.DocumentNumber[0]);",
+					"                    pm.environment.set(tktNum + '_date', tktDate);",
+					"                });",
+					"            });",
+					"            break;",
+					"        case 'TP_CreateRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const proposalID = result.Envelope.Body[0].TP_CreateRS[0].$.proposalID;",
+					"                pm.environment.set('proposal_id', proposalID);",
+					"            });",
+					"            break;",
+					"        case 'TP_ReadRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const proposalVersion = result.Envelope.Body[0].TP_ReadRS[0].TripProposal[0].$.proposalVersion;",
+					"                pm.environment.set('proposal_version', proposalVersion);",
+					"            });",
+					"            break;",
+					"        case 'TP_RefreshRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const proposalVersion = result.Envelope.Body[0].TP_RefreshRS[0].TripProposal[0].$.proposalVersion;",
+					"                pm.environment.set('proposal_version', proposalVersion);",
+					"            });",
+					"            break;",
+					"        case 'GetHotelAvailRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const hotelCode = result.Envelope.Body[0].GetHotelAvailRS[0].HotelAvailInfos[0].HotelAvailInfo[0].HotelInfo[0].$.HotelCode;",
+					"                pm.environment.set('hotel_code', hotelCode);",
+					"            });",
+					"            break;",
+					"        case 'GetHotelDetailsRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const rateKey = result.Envelope.Body[0].GetHotelDetailsRS[0].HotelDetailsInfo[0].HotelRateInfo[0].RateInfos[0].RateInfo[0].$.RateKey;",
+					"                pm.environment.set('rate_key', rateKey);",
+					"            });",
+					"            break;",
+					"        case 'HotelPriceCheckRQ':",
+					"            parseString(responseBody, parseOptions, (err, result) => {",
+					"                const bookingKey = result.Envelope.Body[0].HotelPriceCheckRS[0].PriceCheckInfo[0].$.BookingKey;",
+					"                pm.environment.set('booking_key', bookingKey);",
+					"            });",
+					"            break;",
+					"        // Add new API here",
+					"    }",
+					"",
+					"",
+					"} else {",
+					"",
+					"    //***REST Path***//",
+					"",
+					"    // Get the Unique ID of the URI (token, shop, price, create, view, cancel, change) based on the \"5th\" string in order to identify the actual API",
+					"    const URI_ID = request.url.split(\"/\")[5];",
+					"",
+					"    // Get the JSON response",
+					"    const jsonData = JSON.parse(responseBody);",
+					"",
+					"    switch (URI_ID) {",
+					"",
+					"        case 'token':",
+					"            pm.environment.set('token', jsonData.access_token);",
+					"            break;",
+					"        case 'shop':",
+					"            pm.environment.set('shop_offer_id', jsonData.groupedItineraryResponse.itineraryGroups[0].itineraries[0].pricingInformation[0].offer.offerId);",
+					"            //pm.environment.set('shop_offer_item_id', jsonData.groupedItineraryResponse.itineraryGroups[0].itineraries[0].pricingInformation[0].fare.offerItemId);",
+					"            pm.environment.set('shop_offer_item_id', jsonData.groupedItineraryResponse.itineraryGroups[0].itineraries[0].pricingInformation[0].fare.passengerInfoList[0].passengerInfo.offerItemId);",
+					"            break;",
+					"        case 'price':",
+					"            pm.environment.set('price_offer_id', jsonData.response.offers[0].id);",
+					"            pm.environment.set('price_offer_item_id', jsonData.response.offers[0].offerItems[0].id);",
+					"            pm.environment.set('price_passenger_id', jsonData.response.offers[0].offerItems[0].passengers[0].id);",
+					"            break;",
+					"        case 'create':",
+					"            pm.environment.set('sabre_order_id', jsonData.order.id);",
+					"            pm.environment.set('pnr', jsonData.order.pnrLocator);",
+					"            break;",
+					"        case 'hotelavail':",
+					"            pm.environment.set('hotel_code', jsonData.GetHotelAvailRS.HotelAvailInfos.HotelAvailInfo[0].HotelInfo.HotelCode);",
+					"            pm.environment.set('rate_key', jsonData.GetHotelAvailRS.HotelAvailInfos.HotelAvailInfo[0].HotelRateInfo.RateInfos.RateInfo[0].RateKey);",
+					"            break;",
+					"        case 'hoteldetails':",
+					"            pm.environment.set('rate_key', jsonData.GetHotelDetailsRS.HotelDetailsInfo.HotelRateInfo.RateInfos.RateInfo[0].RateKey);",
+					"            break;",
+					"        case 'pricecheck':",
+					"            pm.environment.set('booking_key', jsonData.HotelPriceCheckRS.PriceCheckInfo.BookingKey);",
+					"            break;",
+					"        case 'records?mode=create':",
+					"            pm.environment.set('pnr', jsonData.CreatePassengerNameRecordRS.ItineraryRef.ID);",
+					"            break;",
+					"        case 'orders':",
+					"            if ((request.url.split(\"/\")[6]) == ('createBooking')) {",
+					"                pm.environment.set('pnr', jsonData.confirmationId);",
+					"            };",
+					"",
+					"            break;",
+					"    }",
+					"}",
+					"",
+					""
+				]
+			}
+		}
+	]
+}


### PR DESCRIPTION
Extended collection with the examples for the newly added features:
- createBooking supports sending other service information (OSI).
- createBooking allows filtering the profiles by ID.
- checkFlightTickets starts supporting requests by confirmationId. This allows you to check all ATPCO-Tickets of a reservation and check the refund or void option of a NDC Order.
- cancelBooking supports voids or refunds for NDC orders.